### PR TITLE
docs: update scanner instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ They handle two roles: **Scanner Agent** and **Deployment Agent**.
 
 **Purpose:** Periodically scan the Zcash Community Forum “What are you listening to?” thread and produce an up-to-date `videos.json`.
 
-- **Codebase:** [`zcash-radio-scan/`](./zcash-radio-scan)
+ - **Codebase:** [Rust scanner crate at repo root](./)
 - **Language:** Rust
 - **Entry point:** `src/main.rs`
 - **Behavior:**

--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ Clone the repo:
 ```sh
 git clone https://github.com/aphelionz/zcash-radio.git
 cd zcash-radio
+```
 
 Build the Rust scanner (requires Rust stable):
 
-cargo run --release --manifest-path zcash-radio-scan/Cargo.toml
+```sh
+cargo run --release
 ```
 
-This produces public/videos.json.
+This produces `public/videos.json`.
+Use `--topic-url`, `--out`, or `--chunked` to customize the scan.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- fix README build instructions for scanner
- clarify optional CLI flags
- correct AGENTS codebase path

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2ab1b468832da5e90751f9d6ee1d