### PR TITLE
chore: remove created_at field from Post

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,8 +47,6 @@ struct Post {
     id: i64,
     post_number: i64,
     cooked: String,
-    #[serde(default)]
-    created_at: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
## Summary
- drop the unused `created_at` field from the `Post` struct

## Testing
- `cargo fmt --all`
- `cargo test --quiet`
- `cargo run --quiet -- --topic-url http://localhost:8000/topic`

------
https://chatgpt.com/codex/tasks/task_e_68bca3379860832daf5709a76d404643