### PR TITLE
Simplify videos.json generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ They handle two roles: **Scanner Agent** and **Deployment Agent**.
   1. Fetch the topic JSON from Discourse (`print=true` or chunked).
   2. Parse each post’s HTML for YouTube links.
   3. Normalize to canonical video IDs.
-  4. Deduplicate and upsert into `public/videos.json`.
+  4. Deduplicate and overwrite `public/videos.json`.
   5. Include metadata: first-seen post, last-seen timestamp, and source link.
 
 **Trigger:** Runs inside the `build` job of the GitHub Actions workflow.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ struct Args {
     )]
     topic_url: String,
 
-    /// Output JSON file (will be created/updated)
+    /// Output JSON file (will be overwritten)
     #[arg(long, default_value = "./public/videos.json")]
     out: PathBuf,
 
@@ -82,12 +82,7 @@ async fn main() -> Result<()> {
         get_topic_chunked(&client, topic_url).await?
     };
 
-    let mut map: HashMap<String, VideoEntry> = if args.out.exists() {
-        let data = fs::read_to_string(&args.out)?;
-        serde_json::from_str(&data).unwrap_or_default()
-    } else {
-        HashMap::with_capacity(posts.len())
-    };
+    let mut map: HashMap<String, VideoEntry> = HashMap::with_capacity(posts.len());
 
     let mut process = |p: Post| {
         let doc = Html::parse_fragment(&p.cooked);
@@ -175,7 +170,7 @@ async fn main() -> Result<()> {
     let json = serde_json::to_string_pretty(&map)?;
     fs::write(&args.out, json)?;
 
-    eprintln!("Upserted {} unique videos into {}", len, args.out.display());
+    eprintln!("Wrote {} unique videos to {}", len, args.out.display());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Drop upsert behavior for `videos.json` and always overwrite
- Reflect new overwrite behavior in AGENTS instructions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4a7b7d20832da46a96d624e67bca