### PR TITLE
Simplify topic fetching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ They handle two roles: **Scanner Agent** and **Deployment Agent**.
 - **Language:** Rust
 - **Entry point:** `src/main.rs`
 - **Behavior:**
-  1. Fetch the topic JSON from Discourse (`print=true` or chunked).
+  1. Fetch the topic JSON from Discourse (`print=true`).
   2. Parse each post’s HTML for YouTube links.
   3. Normalize to canonical video IDs.
   4. Deduplicate and overwrite `public/videos.json`.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cargo run --release
 ```
 
 This produces `public/videos.json`.
-Use `--topic-url`, `--out`, or `--chunked` to customize the scan.
+Use `--topic-url` or `--out` to customize the scan.
 
 ## Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,7 @@ const OUT_PATH: &str = "./public/videos.json";
 
 #[derive(Parser, Debug)]
 #[command(name = "zcash-radio-scan", version)]
-struct Args {
-    /// Use chunked fetching via post_ids (safety valve if print=true ever fails)
-    #[arg(long, default_value_t = false)]
-    chunked: bool,
-}
+struct Args {}
 
 #[derive(Debug, Deserialize)]
 struct Topic {
@@ -25,8 +21,6 @@ struct Topic {
 #[derive(Debug, Deserialize)]
 struct PostStream {
     posts: Vec<Post>,
-    #[serde(default)]
-    stream: Vec<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,7 +53,7 @@ fn is_valid_youtube_id(id: &str) -> bool {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let _args = Args::parse();
     let topic_url = TOPIC_URL.trim_end_matches('/');
     let client = reqwest::Client::builder()
         .user_agent("zcash-radio-aphelionz/0.1 (+https://github.com/aphelionz)")
@@ -68,11 +62,16 @@ async fn main() -> Result<()> {
     // Extract and canonicalize YouTube IDs
     let a_sel = Selector::parse("a").unwrap();
 
-    let posts = if !args.chunked {
-        get_topic_print(&client, topic_url).await?
-    } else {
-        get_topic_chunked(&client, topic_url).await?
-    };
+    let url = format!("{}.json?print=true", topic_url);
+    let resp = client.get(&url).send().await?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        eprintln!("DISCOURSE ERROR {} -> {}\n{}", url, status, body);
+        anyhow::bail!("GET {}", url);
+    }
+    let topic: Topic = resp.json().await?;
+    let posts = topic.post_stream.posts;
 
     let mut map: HashMap<String, VideoEntry> = HashMap::with_capacity(posts.len());
 
@@ -164,63 +163,4 @@ async fn main() -> Result<()> {
 
     eprintln!("Wrote {} unique videos to {}", len, OUT_PATH);
     Ok(())
-}
-
-async fn get_topic_print(client: &reqwest::Client, topic_url: &str) -> Result<Vec<Post>> {
-    let url = format!("{}.json?print=true", topic_url.trim_end_matches('/'));
-    let resp = client.get(&url).send().await?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        eprintln!("DISCOURSE ERROR {} -> {}\n{}", url, status, body);
-        anyhow::bail!("GET {}", url);
-    }
-    let topic: Topic = resp.json().await?;
-    Ok(topic.post_stream.posts)
-}
-
-// Safety valve: fetch first page, then chunk via /t/{id}/posts.json?post_ids[]=...
-async fn get_topic_chunked(client: &reqwest::Client, topic_url: &str) -> Result<Vec<Post>> {
-    let base_url = topic_url.trim_end_matches('/');
-    let base = format!("{}.json", base_url);
-    let resp = client.get(&base).send().await?;
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        eprintln!("DISCOURSE ERROR {} -> {}\n{}", base, status, body);
-        anyhow::bail!("GET {}", base);
-    }
-
-    let t: Topic = resp.json().await?;
-
-    let mut posts = t.post_stream.posts;
-    let stream = t.post_stream.stream;
-    let ids = stream.get(20..).unwrap_or(&[]);
-
-    for chunk in ids.chunks(20) {
-        let post_ids: Vec<String> = chunk.iter().map(|id| format!("post_ids={}", id)).collect();
-        let url = format!("{}/posts.json?{}", base_url, post_ids.join("&"));
-
-        let resp = client.get(&url).send().await?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            eprintln!("DISCOURSE ERROR {} -> {}\n{}", url, status, body);
-            // Skip this chunk but continue
-            continue;
-        }
-
-        let topic = match resp.json::<Topic>().await {
-            Ok(topic) => topic,
-            Err(err) => {
-                eprintln!("PARSE ERROR {} -> {}", url, err);
-                // Skip this chunk on parse error
-                continue;
-            }
-        };
-        posts.extend(topic.post_stream.posts);
-
-        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
-    }
-    Ok(posts)
 }


### PR DESCRIPTION
## Summary
- remove chunked fetching and related CLI flag
- inline Discourse topic fetch into `main`
- adjust documentation to match

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bd663cf834832db003b8a3f3c1de7b