### PR TITLE
docs: remove stale CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ cargo run --release
 ```
 
 This produces `public/videos.json`.
-Use `--topic-url` or `--out` to customize the scan.
+To change the source thread or output path, modify the `TOPIC_URL` and
+`OUT_PATH` constants in `src/main.rs`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- update README to remove outdated `--topic-url` and `--out` CLI flags and mention modifying constants instead

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68bd699731a8832d8e6fe930098b1a0e