### PR TITLE
Embed curated denylist at compile time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,12 @@ static CURATION_DENYLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
                     return None;
                 }
             }
-            let id = line.split('|').map(|p| p.trim()).next().unwrap_or("");
-            if is_valid_youtube_id(id) {
-                Some(id)
+            if let Some(id) = line.split('|').map(|p| p.trim()).next() {
+                if !id.is_empty() && is_valid_youtube_id(id) {
+                    Some(id)
+                } else {
+                    None
+                }
             } else {
                 None
             }


### PR DESCRIPTION
## Summary
- embed `curation.txt` via `include_str!` and a static `LazyLock` `HashSet`
- remove runtime file loading and `load_curation`
- drop `once_cell` dependency in favor of `std::sync::LazyLock`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bde1e42624832db3c80ada6f144f72