### PR TITLE
Use a shared reqwest client

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,13 @@ use std::fs;
 use std::sync::LazyLock;
 use url::Url;
 
+static CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .user_agent("zcash-radio-aphelionz/0.1 (+https://github.com/aphelionz)")
+        .build()
+        .expect("client")
+});
+
 pub static CURATION_DENYLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     include_str!("../curation.txt")
         .lines()
@@ -146,12 +153,8 @@ pub fn process_posts(
 
 pub async fn run(topic_url: &str, out_path: &str) -> Result<usize> {
     let topic_url = topic_url.trim_end_matches('/');
-    let client = Client::builder()
-        .user_agent("zcash-radio-aphelionz/0.1 (+https://github.com/aphelionz)")
-        .build()?;
-
     let url = format!("{}.json?print=true", topic_url);
-    let resp = client.get(&url).send().await?;
+    let resp = CLIENT.get(&url).send().await?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
         .user_agent("zcash-radio-aphelionz/0.1 (+https://github.com/aphelionz)")
         .build()
-        .expect("client")
+        .expect("Failed to build HTTP client")
 });
 
 pub static CURATION_DENYLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary
- initialize a static reqwest `Client` with custom user agent
- reuse the shared client in `run`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be3c3fe0c4832d9ac338fa3c2d423a