### PR TITLE
Use Entry::Vacant for video map insertion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
 use serde_json;
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::fs;
 use std::sync::LazyLock;
 use url::Url;
@@ -132,11 +132,16 @@ pub fn process_posts(
                         eprintln!("curation: skipped {}", video_id);
                         continue;
                     }
-                    map.entry(video_id.clone()).or_insert_with(|| VideoEntry {
-                        video_id: video_id.clone(),
-                        source_post_url: format!("{}/{}", topic_url, p.post_number),
-                        username: p.username.clone(),
-                    });
+                    match map.entry(video_id.clone()) {
+                        Entry::Vacant(v) => {
+                            v.insert(VideoEntry {
+                                video_id: video_id.clone(),
+                                source_post_url: format!("{}/{}", topic_url, p.post_number),
+                                username: p.username.clone(),
+                            });
+                        }
+                        Entry::Occupied(_) => {}
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,10 +132,11 @@ pub fn process_posts(
                         eprintln!("curation: skipped {}", video_id);
                         continue;
                     }
-                    match map.entry(video_id.clone()) {
+                    let video_id_clone = video_id.clone();
+                    match map.entry(video_id) {
                         Entry::Vacant(v) => {
                             v.insert(VideoEntry {
-                                video_id: video_id.clone(),
+                                video_id: video_id_clone,
                                 source_post_url: format!("{}/{}", topic_url, p.post_number),
                                 username: p.username.clone(),
                             });


### PR DESCRIPTION
## Summary
- import `std::collections::hash_map::Entry`
- replace `or_insert_with` with an `Entry::Vacant` match when inserting `VideoEntry`

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be3c42aaa4832db355b22a15a33d26