### PR TITLE
Use ASCII lowercase for host normalization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub fn is_valid_youtube_id(id: &str) -> bool {
 
 pub fn extract_video_id(href: &str) -> Option<String> {
     let u = Url::parse(href).ok()?;
-    let host = u.host_str()?.to_lowercase();
+    let host = u.host_str()?.to_ascii_lowercase();
     let is_youtube = host == "youtu.be" || host.ends_with("youtube.com");
     if !is_youtube {
         return None;


### PR DESCRIPTION
## Summary
- replace Unicode-based `to_lowercase` with `to_ascii_lowercase` when normalizing hostnames in `extract_video_id`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68be4e824da8832d886fa395e026d108