### PR TITLE
Use static selector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("Failed to build HTTP client")
 });
 
+static A_SELECTOR: LazyLock<Selector> = LazyLock::new(|| Selector::parse("a").unwrap());
+
 pub static CURATION_DENYLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     include_str!("../curation.txt")
         .lines()
@@ -113,11 +115,10 @@ pub fn process_posts(
     topic_url: &str,
     denylist: &HashSet<&str>,
 ) -> HashMap<String, VideoEntry> {
-    let a_sel = Selector::parse("a").unwrap();
     let mut map: HashMap<String, VideoEntry> = HashMap::with_capacity(posts.len());
     for p in posts {
         let doc = Html::parse_fragment(&p.cooked);
-        for a in doc.select(&a_sel) {
+        for a in doc.select(&*A_SELECTOR) {
             if let Some(href) = a.value().attr("href") {
                 if !(href.contains("youtu.be") || href.contains("youtube.com")) {
                     continue;


### PR DESCRIPTION
## Summary
- Add a global LazyLock `A_SELECTOR` for the common anchor selector
- Reuse the global selector in `process_posts` instead of parsing each time

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68be4e7a1cfc832d9017a08239c2da10