### PR TITLE
Refactor extract_video_id path handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,13 @@ pub fn extract_video_id(href: &str) -> Option<String> {
         return None;
     }
 
-    if let Some(rest) = path
-        .strip_prefix("/shorts/")
-        .or_else(|| path.strip_prefix("/embed/"))
-        .or_else(|| path.strip_prefix("/live/"))
-    {
+    let rest = match path {
+        p if p.starts_with("/shorts/") => Some(&p["/shorts/".len()..]),
+        p if p.starts_with("/embed/") => Some(&p["/embed/".len()..]),
+        p if p.starts_with("/live/") => Some(&p["/live/".len()..]),
+        _ => None,
+    };
+    if let Some(rest) = rest {
         let id = rest.split('/').next().unwrap_or("");
         if is_valid_youtube_id(id) {
             return Some(id.to_string());


### PR DESCRIPTION
## Summary
- handle YouTube path prefixes using `match`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be4e8d3068832d8e7d7716aa9e4577