### PR TITLE
Skip HTML parsing for posts without YouTube marker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ pub fn process_posts(
     let a_sel = Selector::parse("a").unwrap();
     let mut map: HashMap<String, VideoEntry> = HashMap::with_capacity(posts.len());
     for p in posts {
+        if !p.cooked.contains("youtu") {
+            continue;
+        }
         let doc = Html::parse_fragment(&p.cooked);
         for a in doc.select(&a_sel) {
             if let Some(href) = a.value().attr("href") {


### PR DESCRIPTION
## Summary
- Avoid HTML parsing in `process_posts` when post HTML lacks `youtu`

## Testing
- `cargo test`
- `hyperfine 'cargo run --release --example bench >/dev/null' --warmup 1` (synthetic dump)


------
https://chatgpt.com/codex/tasks/task_e_68be4f03df08832d836734b100c35285