### PR TITLE
Add Criterion benchmarks for scanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +386,58 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "concurrent-queue"
@@ -393,6 +463,62 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -619,12 +745,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -683,6 +824,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -769,6 +911,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -1142,6 +1294,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,7 +1356,7 @@ dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -1347,6 +1519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1541,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
@@ -1576,6 +1763,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1964,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2332,6 +2567,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2946,6 +3191,7 @@ name = "zcash-radio-scan"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "httpmock",
  "reqwest",
  "scraper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ url = "2"
 [dev-dependencies]
 httpmock = "0.7"
 tempfile = "3"
-criterion = { version = "0.5", features = ["async"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 
 [[bench]]
 name = "scanner_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ url = "2"
 [dev-dependencies]
 httpmock = "0.7"
 tempfile = "3"
+criterion = { version = "0.5", features = ["async"] }
+
+[[bench]]
+name = "scanner_bench"
+harness = false

--- a/benches/scanner_bench.rs
+++ b/benches/scanner_bench.rs
@@ -2,9 +2,10 @@ use std::collections::HashSet;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use httpmock::MockServer;
-use tempfile::NamedTempFile;
+use tempfile::tempdir;
 use tokio::runtime::Runtime;
 use zcash_radio_scan::{process_posts, run, Post};
+use std::sync::Arc;
 
 fn bench_process_posts(c: &mut Criterion) {
     // Generate a list of posts with unique YouTube links
@@ -29,7 +30,6 @@ fn bench_process_posts(c: &mut Criterion) {
 }
 
 fn bench_run_with_mock(c: &mut Criterion) {
-    let rt = Runtime::new().unwrap();
     let server = MockServer::start();
 
     // Sample topic JSON served by the mock server
@@ -50,14 +50,24 @@ fn bench_run_with_mock(c: &mut Criterion) {
             .json_body_obj(&topic_json);
     });
 
-    let url = format!("{}/topic", server.base_url());
-    let tmp = NamedTempFile::new().unwrap();
-    let out_path = tmp.path().to_str().unwrap().to_string();
+    let url = Arc::new(format!("{}/topic", server.base_url()));
+    let tmp_dir = tempdir().unwrap();
+    let out_path = tmp_dir.path().join("videos.json");
+    let out_path = Arc::new(out_path.to_str().unwrap().to_string());
+    let rt = Runtime::new().unwrap();
 
     c.bench_function("run_with_mock", |b| {
-        b.iter(|| {
-            rt.block_on(run(black_box(&url), black_box(&out_path))).unwrap();
-        })
+        let url = Arc::clone(&url);
+        let out_path = Arc::clone(&out_path);
+        b.to_async(&rt).iter(move || {
+            let url = Arc::clone(&url);
+            let out_path = Arc::clone(&out_path);
+            async move {
+                run(black_box(&url), black_box(&out_path))
+                    .await
+                    .unwrap();
+            }
+        });
     });
 }
 

--- a/benches/scanner_bench.rs
+++ b/benches/scanner_bench.rs
@@ -1,0 +1,65 @@
+use std::collections::HashSet;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use httpmock::MockServer;
+use tempfile::NamedTempFile;
+use tokio::runtime::Runtime;
+use zcash_radio_scan::{process_posts, run, Post};
+
+fn bench_process_posts(c: &mut Criterion) {
+    // Generate a list of posts with unique YouTube links
+    let posts: Vec<Post> = (0..1000)
+        .map(|i| {
+            let id = format!("ID{:09}", i);
+            Post {
+                post_number: i as i64,
+                cooked: format!("<a href=\"https://youtu.be/{id}\">v</a>"),
+                username: format!("user{i}"),
+            }
+        })
+        .collect();
+    let denylist: HashSet<&str> = HashSet::new();
+
+    c.bench_function("process_posts", |b| {
+        b.iter(|| {
+            let map = process_posts(black_box(&posts), black_box("https://forum"), black_box(&denylist));
+            black_box(map);
+        })
+    });
+}
+
+fn bench_run_with_mock(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let server = MockServer::start();
+
+    // Sample topic JSON served by the mock server
+    let topic_json = serde_json::json!({
+        "post_stream": {"posts": [{
+            "post_number": 1,
+            "cooked": "<a href=\"https://youtu.be/BBBBBBBBBBB\">v</a>",
+            "username": "alice"
+        }]}
+    });
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::GET)
+            .path("/topic.json")
+            .query_param("print", "true");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body_obj(&topic_json);
+    });
+
+    let url = format!("{}/topic", server.base_url());
+    let tmp = NamedTempFile::new().unwrap();
+    let out_path = tmp.path().to_str().unwrap().to_string();
+
+    c.bench_function("run_with_mock", |b| {
+        b.iter(|| {
+            rt.block_on(run(black_box(&url), black_box(&out_path))).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_process_posts, bench_run_with_mock);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- add Criterion dev-dependency and benchmark configuration
- benchmark `process_posts` with synthetic posts
- benchmark `run` using a mock HTTP server to avoid real network delays

## Testing
- `cargo test`
- `cargo bench --bench scanner_bench`


------
https://chatgpt.com/codex/tasks/task_e_68be5170d504832db6e3bbf7ad5e1f63